### PR TITLE
Clean out serial loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ubiquity_motor)
 
+add_definitions(-std=c++11)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/include/ubiquity_motor/motor_message.h
+++ b/include/ubiquity_motor/motor_message.h
@@ -147,6 +147,8 @@ public:
 
     int deserialize(const RawMotorMessage &serialized);
 
+    const static uint8_t delimeter = 0x7E; // TODO: parameterize
+
 private:
     // Type of message should be in MotorMessage::MessageTypes
     uint8_t type;
@@ -156,8 +158,6 @@ private:
     // 4 bytes of data, numbers should be in big endian format
     boost::array<uint8_t, 4> data;
 
-    const static uint8_t delimeter =
-        0x7E;  // Hard coded for now, should be parameterized
     const static uint8_t protocol_version =
         0x03;  // Hard coded for now, should be parameterized
 

--- a/include/ubiquity_motor/motor_message.h
+++ b/include/ubiquity_motor/motor_message.h
@@ -147,7 +147,7 @@ public:
 
     int deserialize(const RawMotorMessage &serialized);
 
-    const static uint8_t delimeter = 0x7E; // TODO: parameterize
+    const static uint8_t delimeter = 0x7E;  // TODO: parameterize
 
 private:
     // Type of message should be in MotorMessage::MessageTypes

--- a/include/ubiquity_motor/motor_parmeters.h
+++ b/include/ubiquity_motor/motor_parmeters.h
@@ -98,8 +98,6 @@ struct CommsParams {
             nh, "ubiquity_motor/serial_port", serial_port);
         baud_rate = getParamOrDefault(
             nh, "ubiquity_motor/serial_baud", baud_rate);
-        serial_loop_rate = getParamOrDefault(
-            nh, "ubiquity_motor/serial_loop_rate", serial_loop_rate);
         // clang-format on
     };
 };

--- a/include/ubiquity_motor/motor_serial.h
+++ b/include/ubiquity_motor/motor_serial.h
@@ -61,7 +61,7 @@ private:
     shared_queue<MotorMessage> output;
 
     boost::thread serial_thread;
-    
+
     void appendOutput(MotorMessage command);
 
     // Thread that has manages serial reads

--- a/include/ubiquity_motor/motor_serial.h
+++ b/include/ubiquity_motor/motor_serial.h
@@ -58,19 +58,14 @@ public:
 private:
     serial::Serial motors;
 
-    // queue for messages that are to be transmitted
-    shared_queue<MotorMessage> input;
-
     shared_queue<MotorMessage> output;
 
     boost::thread serial_thread;
     ros::Rate serial_loop_rate;
 
-    int inputAvailable();
-    MotorMessage getInputCommand();
     void appendOutput(MotorMessage command);
 
-    // Thread that has manages the serial port
+    // Thread that has manages serial reads
     void SerialThread();
 
     FRIEND_TEST(MotorSerialTests, serialClosedOnInterupt);

--- a/include/ubiquity_motor/motor_serial.h
+++ b/include/ubiquity_motor/motor_serial.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class MotorSerial {
 public:
     MotorSerial(const std::string& port = "/dev/ttyUSB0",
-                uint32_t baud_rate = 9600, double loopRate = 100);
+                uint32_t baud_rate = 9600);
     ~MotorSerial();
 
     int transmitCommand(MotorMessage command);
@@ -61,8 +61,7 @@ private:
     shared_queue<MotorMessage> output;
 
     boost::thread serial_thread;
-    ros::Rate serial_loop_rate;
-
+    
     void appendOutput(MotorMessage command);
 
     // Thread that has manages serial reads

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -63,8 +63,7 @@ MotorHardware::MotorHardware(ros::NodeHandle nh, CommsParams serial_params,
     registerInterface(&velocity_joint_interface_);
 
     motor_serial_ =
-        new MotorSerial(serial_params.serial_port, serial_params.baud_rate,
-                        serial_params.serial_loop_rate);
+        new MotorSerial(serial_params.serial_port, serial_params.baud_rate);
 
     leftError = nh.advertise<std_msgs::Int32>("left_error", 1);
     rightError = nh.advertise<std_msgs::Int32>("right_error", 1);

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -88,8 +88,8 @@ int main(int argc, char* argv[]) {
     robot.requestVersion();
 
     int times = 0;
-    while(robot.firmware_version == 0) {
-        if(times >= 10)
+    while (robot.firmware_version == 0) {
+        if (times >= 10)
             throw std::runtime_error("Firmware not reporting its version");
         robot.readInputs();
         r.sleep();

--- a/src/motor_serial.cc
+++ b/src/motor_serial.cc
@@ -32,10 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <serial/serial.h>
 #include <ubiquity_motor/motor_serial.h>
 
-MotorSerial::MotorSerial(const std::string& port, uint32_t baud_rate,
-                         double loopRate)
-    : motors(port, baud_rate, serial::Timeout::simpleTimeout(100)),
-      serial_loop_rate(loopRate) {
+MotorSerial::MotorSerial(const std::string& port, uint32_t baud_rate)
+    : motors(port, baud_rate, serial::Timeout::simpleTimeout(100)) {
     serial_thread = boost::thread(&MotorSerial::SerialThread, this);
 }
 

--- a/src/motor_serial.cc
+++ b/src/motor_serial.cc
@@ -45,19 +45,17 @@ MotorSerial::~MotorSerial() {
 
 int MotorSerial::transmitCommand(MotorMessage command) {
     RawMotorMessage out = command.serialize();
-    ROS_DEBUG("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0],
-          out[1], out[2], out[3], out[4], out[5], out[6],
-          out[7]);
+    ROS_DEBUG("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0], out[1],
+              out[2], out[3], out[4], out[5], out[6], out[7]);
     motors.write(out.c_array(), out.size());
     return 0;
 }
 
 int MotorSerial::transmitCommands(const std::vector<MotorMessage>& commands) {
-    for (auto& command: commands) {
+    for (auto& command : commands) {
         RawMotorMessage out = command.serialize();
-        ROS_DEBUG("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0],
-            out[1], out[2], out[3], out[4], out[5], out[6],
-            out[7]);
+        ROS_DEBUG("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0], out[1],
+                  out[2], out[3], out[4], out[5], out[6], out[7]);
         motors.write(out.c_array(), out.size());
         boost::this_thread::sleep(boost::posix_time::milliseconds(2));
     }
@@ -81,10 +79,10 @@ void MotorSerial::SerialThread() {
         while (motors.isOpen()) {
             boost::this_thread::interruption_point();
             if (motors.waitReadable()) {
-                RawMotorMessage innew = {0,0,0,0,0,0,0,0};
+                RawMotorMessage innew = {0, 0, 0, 0, 0, 0, 0, 0};
 
                 motors.read(innew.c_array(), 1);
-                if (innew[0] != MotorMessage::delimeter){
+                if (innew[0] != MotorMessage::delimeter) {
                     // The first byte was not the delimiter, so re-loop
                     ROS_WARN("REJECT %02x", innew[0]);
                     continue;
@@ -95,21 +93,19 @@ void MotorSerial::SerialThread() {
 
                 // Read in next 7 bytes
                 motors.read(&innew.c_array()[1], 7);
-                ROS_DEBUG("Got message %x %x %x %x %x %x %x %x", 
-                    innew[0], innew[1], innew[2], innew[3],
-                    innew[4], innew[5], innew[6], innew[7]);
+                ROS_DEBUG("Got message %x %x %x %x %x %x %x %x", innew[0],
+                          innew[1], innew[2], innew[3], innew[4], innew[5],
+                          innew[6], innew[7]);
 
                 MotorMessage mc;
                 int error_code = mc.deserialize(innew);
                 if (error_code == 0) {
                     appendOutput(mc);
                     if (mc.getType() == MotorMessage::TYPE_ERROR) {
-                        ROS_ERROR(
-                            "GOT error from Firm 0x%02x",
-                            mc.getRegister());
+                        ROS_ERROR("GOT error from Firm 0x%02x",
+                                  mc.getRegister());
                     }
-                }
-                else {
+                } else {
                     ROS_ERROR("DESERIALIZATION ERROR! - %d", error_code);
                 }
             }

--- a/src/motor_serial.cc
+++ b/src/motor_serial.cc
@@ -47,7 +47,7 @@ MotorSerial::~MotorSerial() {
 
 int MotorSerial::transmitCommand(MotorMessage command) {
     RawMotorMessage out = command.serialize();
-    ROS_ERROR("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0],
+    ROS_DEBUG("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0],
           out[1], out[2], out[3], out[4], out[5], out[6],
           out[7]);
     motors.write(out.c_array(), out.size());
@@ -57,7 +57,7 @@ int MotorSerial::transmitCommand(MotorMessage command) {
 int MotorSerial::transmitCommands(const std::vector<MotorMessage>& commands) {
     for (auto& command: commands) {
         RawMotorMessage out = command.serialize();
-        ROS_ERROR("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0],
+        ROS_DEBUG("out %02x %02x %02x %02x %02x %02x %02x %02x", out[0],
             out[1], out[2], out[3], out[4], out[5], out[6],
             out[7]);
         motors.write(out.c_array(), out.size());

--- a/test/motor_hardware_test.cc
+++ b/test/motor_hardware_test.cc
@@ -54,7 +54,7 @@ protected:
             ASSERT_NE(-1, ioctl(master_fd, TIOCOUTQ, &count_out));
         }
         EXPECT_EQ(0, count_out);
-        usleep(1000);
+        usleep(10000);
     }
 
     MotorHardware *robot;

--- a/test/motor_serial_test.cc
+++ b/test/motor_serial_test.cc
@@ -55,7 +55,7 @@ protected:
         ASSERT_TRUE(std::string(name).length() > 0);
 
         ros::Time::init();
-        motors = new MotorSerial(std::string(name), 9600, 1000);
+        motors = new MotorSerial(std::string(name), 9600);
     }
 
     virtual void TearDown() { delete motors; }
@@ -67,7 +67,7 @@ protected:
 };
 
 TEST(MotorSerialNoFixtureTests, badPortnameException) {
-    ASSERT_THROW(MotorSerial motors(std::string("foo"), 9600, 1000),
+    ASSERT_THROW(MotorSerial motors(std::string("foo"), 9600),
                  serial::IOException);
 }
 


### PR DESCRIPTION
Commands are now transmitted directly, without going through a queue.
The reading loop properly waits for serial data, and handles the input better.