### PR TITLE
Enhance ESTOP recovery. Publish motor power state on topic. Clarify a Deserialization error

### DIFF
--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -96,7 +96,8 @@ public:
     virtual ~MotorHardware();
     void clearCommands();
     void readInputs();
-    void writeSpeeds(bool zeroSpeeds);
+    void writeSpeeds();
+    void writeSpeedsWithDisable(bool disableSpeeds);
     void requestVersion();
     void setParams(FirmwareParams firmware_params);
     void sendParams();

--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -97,7 +97,7 @@ public:
     void clearCommands();
     void readInputs();
     void writeSpeeds();
-    void writeSpeedsWithDisable(bool disableSpeeds);
+    void writeSpeedsInRadians(double  left_radians, double  right_radians);
     void requestVersion();
     void setParams(FirmwareParams firmware_params);
     void sendParams();

--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -65,6 +65,11 @@ struct MotorDiagnostics {
     bool right_pwm_limit = false;
     bool left_integral_limit = false;
     bool right_integral_limit = false;
+    bool left_max_speed_limit = false;
+    bool right_max_speed_limit = false;
+
+    // Motor power is inactive, most likely from ESTOP switch
+    bool estop_motor_power_off = false;
 
     // Power supply statuses
     float battery_voltage = 0.0;

--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -68,9 +68,6 @@ struct MotorDiagnostics {
     bool left_max_speed_limit = false;
     bool right_max_speed_limit = false;
 
-    // Motor power is inactive, most likely from ESTOP switch
-    bool estop_motor_power_off = false;
-
     // Power supply statuses
     float battery_voltage = 0.0;
     /* For later implementation (firmware support)
@@ -84,9 +81,12 @@ struct MotorDiagnostics {
     bool  aux_12V_ol = false;
     */
 
+    bool  estop_motor_power_off = false;  // for Diagnostic reporting of ESTOP switch
+
     void firmware_status(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void limit_status(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void battery_status(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    void motor_power_status(diagnostic_updater::DiagnosticStatusWrapper &stat);
 };
 
 class MotorHardware : public hardware_interface::RobotHW {
@@ -96,7 +96,7 @@ public:
     virtual ~MotorHardware();
     void clearCommands();
     void readInputs();
-    void writeSpeeds();
+    void writeSpeeds(bool zeroSpeeds);
     void requestVersion();
     void setParams(FirmwareParams firmware_params);
     void sendParams();
@@ -105,6 +105,7 @@ public:
     void setHardwareVersion(int32_t hardware_version);
     void setEstopPidThreshold(int32_t estop_pid_threshold);
     void setEstopDetection(int32_t estop_detection);
+    bool getEstopState(void);
     void setMaxFwdSpeed(int32_t max_speed_fwd);
     void setMaxRevSpeed(int32_t max_speed_rev);
     void setMaxPwm(int32_t max_pwm);
@@ -132,6 +133,8 @@ private:
     int32_t deadman_timer;
 
     int32_t sendPid_count;
+
+    bool estop_motor_power_off;    // Motor power inactive, most likely from ESTOP switch
 
     struct Joint {
         double position;

--- a/include/ubiquity_motor/motor_message.h
+++ b/include/ubiquity_motor/motor_message.h
@@ -144,8 +144,13 @@ public:
         LIM_M1_PWM = 0x10,
         LIM_M2_PWM = 0x01,
         LIM_M1_INTEGRAL = 0x20,
-        LIM_M2_INTEGRAL = 0x02
+        LIM_M2_INTEGRAL = 0x02,
+        LIM_M1_MAX_SPD  = 0x40,
+        LIM_M2_MAX_SPD  = 0x4
     };
+
+    // State bits for motor power
+    const static int32_t MOT_POW_ACTIVE = 0x0001;
 
     void setType(MotorMessage::MessageTypes type);
     MotorMessage::MessageTypes getType() const;
@@ -159,6 +164,11 @@ public:
     RawMotorMessage serialize() const;
 
     int deserialize(const RawMotorMessage &serialized);
+    const static int ERR_DELIMITER        = 1; 
+    const static int ERR_WRONG_PROTOCOL   = 2; 
+    const static int ERR_BAD_CHECKSUM     = 3; 
+    const static int ERR_BAD_TYPE         = 4; 
+    const static int ERR_UNKNOWN_REGISTER = 5; 
 
     const static uint8_t delimeter = 0x7E;  // TODO: parameterize
 

--- a/include/ubiquity_motor/motor_message.h
+++ b/include/ubiquity_motor/motor_message.h
@@ -163,14 +163,20 @@ public:
 
     RawMotorMessage serialize() const;
 
-    int deserialize(const RawMotorMessage &serialized);
-    const static int ERR_DELIMITER        = 1; 
-    const static int ERR_WRONG_PROTOCOL   = 2; 
-    const static int ERR_BAD_CHECKSUM     = 3; 
-    const static int ERR_BAD_TYPE         = 4; 
-    const static int ERR_UNKNOWN_REGISTER = 5; 
 
-    const static uint8_t delimeter = 0x7E;  // TODO: parameterize
+    // Error Codes that can be returned by deserializaion
+    enum ErrorCodes {
+        ERR_NONE             = 0, // Success code 
+        ERR_DELIMITER        = 1, 
+        ERR_WRONG_PROTOCOL   = 2, 
+        ERR_BAD_CHECKSUM     = 3, 
+        ERR_BAD_TYPE         = 4, 
+        ERR_UNKNOWN_REGISTER = 5 
+    };
+
+    MotorMessage::ErrorCodes deserialize(const RawMotorMessage &serialized);
+
+    const static uint8_t delimeter = 0x7E;
 
 private:
     // Type of message should be in MotorMessage::MessageTypes

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -229,18 +229,20 @@ void MotorHardware::readInputs() {
     }
 }
 
-// writeSpeeds()  Take in radians per sec for wheels and send in message to controller
+// writeSpeedsWithDisable()  Take in radians per sec for wheels and send in message to controller
 //
 // If zeroSpeeds is true we simply set zero without impacting local state settings
+// This interface allows maintaining of system speed in state but override to zero
+// which is of value for such a case as ESTOP implementation
 //
-void MotorHardware::writeSpeeds(bool zeroSpeeds) {
+void MotorHardware::writeSpeedsWithDisable(bool disableSpeeds) {
     MotorMessage both;
     both.setRegister(MotorMessage::REG_BOTH_SPEED_SET);
     both.setType(MotorMessage::TYPE_WRITE);
     double  left_radians = joints_[0].velocity_command;
     double  right_radians = joints_[1].velocity_command;
 
-    if (zeroSpeeds) {    // Force sending of zero speeds as an override
+    if (disableSpeeds) {    // Force sending of zero speeds as an override
         left_radians  = (double)(0.0);
         right_radians = (double)(0.0);
     }
@@ -260,6 +262,14 @@ void MotorHardware::writeSpeeds(bool zeroSpeeds) {
     // ROS_ERROR("velocity_command %f rad/s %f rad/s",
     // joints_[0].velocity_command, joints_[1].velocity_command);
     // ROS_ERROR("SPEEDS %d %d", left.getData(), right.getData());
+}
+
+// writeSpeeds()  Take in radians per sec for wheels and send in message to controller
+//
+// Legacy interface where no override to zero speeds is supported
+//
+void MotorHardware::writeSpeeds() {
+    writeSpeedsWithDisable(false);
 }
 
 void MotorHardware::requestVersion() {

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -508,6 +508,14 @@ void MotorDiagnostics::limit_status(DiagnosticStatusWrapper &stat) {
         stat.mergeSummary(DiagnosticStatusWrapper::WARN, " right integral,");
 	right_integral_limit = false;
     }
+    if (left_max_speed_limit) {
+        stat.mergeSummary(DiagnosticStatusWrapper::WARN, " left speed,");
+	left_max_speed_limit = false;
+    }
+    if (right_max_speed_limit) {
+        stat.mergeSummary(DiagnosticStatusWrapper::WARN, " right speed,");
+	right_max_speed_limit = false;
+    }
 }
 
 void MotorDiagnostics::battery_status(DiagnosticStatusWrapper &stat) {

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -229,23 +229,16 @@ void MotorHardware::readInputs() {
     }
 }
 
-// writeSpeedsWithDisable()  Take in radians per sec for wheels and send in message to controller
+// writeSpeedsInRadians()  Take in radians per sec for wheels and send in message to controller
 //
-// If zeroSpeeds is true we simply set zero without impacting local state settings
+// A direct write speeds that allows caller setting speeds in radians
 // This interface allows maintaining of system speed in state but override to zero
 // which is of value for such a case as ESTOP implementation
 //
-void MotorHardware::writeSpeedsWithDisable(bool disableSpeeds) {
+void MotorHardware::writeSpeedsInRadians(double  left_radians, double  right_radians) {
     MotorMessage both;
     both.setRegister(MotorMessage::REG_BOTH_SPEED_SET);
     both.setType(MotorMessage::TYPE_WRITE);
-    double  left_radians = joints_[0].velocity_command;
-    double  right_radians = joints_[1].velocity_command;
-
-    if (disableSpeeds) {    // Force sending of zero speeds as an override
-        left_radians  = (double)(0.0);
-        right_radians = (double)(0.0);
-    }
 
     int16_t left_tics = calculateTicsFromRadians(left_radians);
     int16_t right_tics = calculateTicsFromRadians(right_radians);
@@ -266,10 +259,15 @@ void MotorHardware::writeSpeedsWithDisable(bool disableSpeeds) {
 
 // writeSpeeds()  Take in radians per sec for wheels and send in message to controller
 //
-// Legacy interface where no override to zero speeds is supported
+// Legacy interface where no speed overrides are supported
 //
 void MotorHardware::writeSpeeds() {
-    writeSpeedsWithDisable(false);
+    // This call pulls in speeds from the joints array maintained by other layers
+
+    double  left_radians = joints_[0].velocity_command;
+    double  right_radians = joints_[1].velocity_command;
+
+    writeSpeedsInRadians(left_radians, right_radians);
 }
 
 void MotorHardware::requestVersion() {

--- a/src/motor_message.cc
+++ b/src/motor_message.cc
@@ -155,19 +155,20 @@ int MotorMessage::deserialize(const RawMotorMessage &serialized) {
                                   serialized.begin() + 7, data.begin());
                         return 0;
                     } else
-                        return 5;
+                        return MotorMessage::UNKNOWN_REGISTER;
                 } else
-                    return 4;
+                    return MotorMessage::ERR_BAD_TYPE;;
             } else
-                return 3;
+                return MotorMessage::ERR_BAD_CHECKSUM;
         } else
-            return 2;
+            return MotorMessage::ERR_WRONG_PROTOCOL;
     } else
-        return 1;
+        return MotorMessage::ERR_DELIMITER;
 
-    // TODO use exceptions instead of cryptic error codes
+    // TODO use exceptions instead of error codes
 
-    // ERROR codes returned:
+    // ERROR codes returned are defined in MotorMessage class
+    // I leave these here for convienience so double check in the class defines
     // 1 First char not delimiter
     // 2 wrong protocol version
     // 3 bad checksum

--- a/src/motor_message.cc
+++ b/src/motor_message.cc
@@ -155,7 +155,7 @@ int MotorMessage::deserialize(const RawMotorMessage &serialized) {
                                   serialized.begin() + 7, data.begin());
                         return 0;
                     } else
-                        return MotorMessage::UNKNOWN_REGISTER;
+                        return MotorMessage::ERR_UNKNOWN_REGISTER;
                 } else
                     return MotorMessage::ERR_BAD_TYPE;;
             } else

--- a/src/motor_message.cc
+++ b/src/motor_message.cc
@@ -143,7 +143,7 @@ RawMotorMessage MotorMessage::serialize() const {
     return out;
 }
 
-int MotorMessage::deserialize(const RawMotorMessage &serialized) {
+MotorMessage::ErrorCodes MotorMessage::deserialize(const RawMotorMessage &serialized) {
     if (serialized[0] == delimeter) {
         if ((serialized[1] & 0xF0) == (protocol_version << 4)) {
             if (generateChecksum(serialized) == serialized[7]) {
@@ -153,7 +153,7 @@ int MotorMessage::deserialize(const RawMotorMessage &serialized) {
                         this->register_addr = serialized[2];
                         std::copy(serialized.begin() + 3,
                                   serialized.begin() + 7, data.begin());
-                        return 0;
+                        return MotorMessage::ERR_NONE;
                     } else
                         return MotorMessage::ERR_UNKNOWN_REGISTER;
                 } else
@@ -165,15 +165,12 @@ int MotorMessage::deserialize(const RawMotorMessage &serialized) {
     } else
         return MotorMessage::ERR_DELIMITER;
 
-    // TODO use exceptions instead of error codes
-
     // ERROR codes returned are defined in MotorMessage class
-    // I leave these here for convienience so double check in the class defines
-    // 1 First char not delimiter
-    // 2 wrong protocol version
-    // 3 bad checksum
-    // 4 bad type
-    // 5 bad register
+    // First char not delimiter
+    // wrong protocol version
+    // bad checksum
+    // bad type
+    // bad register
 }
 
 int MotorMessage::verifyType(uint8_t t) {

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
 
     // Implement a speed reset while ESTOP is active and a delay after release
     double estopReleaseDeadtime = 0.8;
-    double estopReleaseDelay    = 0.0;;
+    double estopReleaseDelay    = 0.0;
     while (ros::ok()) {
         current_time = ros::Time::now();
         elapsed = current_time - last_time;
@@ -191,7 +191,7 @@ int main(int argc, char* argv[]) {
         } else {
             if (estopReleaseDelay > 0.0) {
                 // Implement a delay after estop release where velocity remains zero
-                estopReleaseDelay -= ((double)(1.0)/node_params.controller_loop_rate);
+                estopReleaseDelay -= (1.0/node_params.controller_loop_rate);
                 robot->writeSpeedsInRadians(0.0, 0.0);
             } else {
                 robot->writeSpeeds();   // Normal operation using current system speeds

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -186,15 +186,15 @@ int main(int argc, char* argv[]) {
 
         // Update motor controller speeds.
         if (robot->getEstopState()) {
-            robot->writeSpeeds(true);    // We send zero velocity when estop is active
+            robot->writeSpeedsWithDisable(true);    // We send zero velocity when estop is active
             estopReleaseDelay = estopReleaseDeadtime;
         } else {
             if (estopReleaseDelay > (double)(0.0)) {
                 // Implement a delay after estop release where velocity remains zero
                 estopReleaseDelay -= ((double)(1.0)/node_params.controller_loop_rate);
-                robot->writeSpeeds(true);
+                robot->writeSpeedsWithDisable(true);
             } else {
-                robot->writeSpeeds(false);   // Normal operation
+                robot->writeSpeeds();   // Normal operation
             }
         }
 

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -164,8 +164,8 @@ int main(int argc, char* argv[]) {
     ROS_WARN("Starting motor control node now");
 
     // Implement a speed reset while ESTOP is active and a delay after release
-    double estopReleaseDeadtime = (double)(0.8);
-    double estopReleaseDelay    = (double)(0.0);;
+    double estopReleaseDeadtime = 0.8;
+    double estopReleaseDelay    = 0.0;;
     while (ros::ok()) {
         current_time = ros::Time::now();
         elapsed = current_time - last_time;
@@ -186,15 +186,15 @@ int main(int argc, char* argv[]) {
 
         // Update motor controller speeds.
         if (robot->getEstopState()) {
-            robot->writeSpeedsWithDisable(true);    // We send zero velocity when estop is active
+            robot->writeSpeedsInRadians(0.0, 0.0);    // We send zero velocity when estop is active
             estopReleaseDelay = estopReleaseDeadtime;
         } else {
-            if (estopReleaseDelay > (double)(0.0)) {
+            if (estopReleaseDelay > 0.0) {
                 // Implement a delay after estop release where velocity remains zero
                 estopReleaseDelay -= ((double)(1.0)/node_params.controller_loop_rate);
-                robot->writeSpeedsWithDisable(true);
+                robot->writeSpeedsInRadians(0.0, 0.0);
             } else {
-                robot->writeSpeeds();   // Normal operation
+                robot->writeSpeeds();   // Normal operation using current system speeds
             }
         }
 

--- a/src/motor_serial.cc
+++ b/src/motor_serial.cc
@@ -110,7 +110,7 @@ void MotorSerial::SerialThread() {
                     }
                 } else {
                     if (++serial_errors > error_threshold) {
-                        if (error_code == MotorMessage::UNKNOWN_REGISTER) {
+                        if (error_code == MotorMessage::ERR_UNKNOWN_REGISTER) {
                             ROS_WARN("Message deserialize found an unrecognized firmware register");
                         } else {
                             ROS_ERROR("DESERIALIZATION ERROR! - %d", error_code);

--- a/src/motor_serial.cc
+++ b/src/motor_serial.cc
@@ -110,7 +110,11 @@ void MotorSerial::SerialThread() {
                     }
                 } else {
                     if (++serial_errors > error_threshold) {
-                        ROS_ERROR("DESERIALIZATION ERROR! - %d", error_code);
+                        if (error_code == MotorMessage::UNKNOWN_REGISTER) {
+                            ROS_WARN("Message deserialize found an unrecognized firmware register");
+                        } else {
+                            ROS_ERROR("DESERIALIZATION ERROR! - %d", error_code);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Make estop state is known to the motor node.
- Publish motor power state in /diagnostics topic
- Switch to ROS_WARN for special case of unknown (new) register seen from firmware
- Send speeds of 0 to controller when in ESTOP and for first fraction of a second after ESTOP release