### PR TITLE
Fix travis build error due to old python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 dist: trusty
 language: python
 python:
-  - "3.4"
+  - "3.6"
 env:
   global:
     - JOB_PATH=/tmp/devel_job


### PR DESCRIPTION
ros_buildfarm needs a newer version of python, so we have travis provide
that.

Related to https://github.com/UbiquityRobotics/ubiquity_main/issues/239