### PR TITLE
A workaround for issue 83.  Insert a delay prior to serial port setup

### DIFF
--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -84,8 +84,19 @@ MotorHardware::MotorHardware(ros::NodeHandle nh, CommsParams serial_params,
     registerInterface(&joint_state_interface_);
     registerInterface(&velocity_joint_interface_);
 
+    // Insert a delay prior to serial port setup to avoid a race defect.
+    // We see soemtimes the OS sets the port to 115200 baud just after we set it
+    ROS_INFO("Delay before MCB serial port initialization");
+    float serialInitDelaySec = 2.0;
+    ros::Rate serialInitDelay(1.0/serialInitDelaySec);
+    serialInitDelay.sleep();
+    ROS_INFO("Initialize MCB serial port '%s' for %d baud",
+        serial_params.serial_port.c_str(), serial_params.baud_rate);
+
     motor_serial_ =
         new MotorSerial(serial_params.serial_port, serial_params.baud_rate);
+
+     ROS_INFO("MCB serial port initialized");
 
     leftError = nh.advertise<std_msgs::Int32>("left_error", 1);
     rightError = nh.advertise<std_msgs::Int32>("right_error", 1);

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -87,9 +87,7 @@ MotorHardware::MotorHardware(ros::NodeHandle nh, CommsParams serial_params,
     // Insert a delay prior to serial port setup to avoid a race defect.
     // We see soemtimes the OS sets the port to 115200 baud just after we set it
     ROS_INFO("Delay before MCB serial port initialization");
-    float serialInitDelaySec = 2.0;
-    ros::Rate serialInitDelay(1.0/serialInitDelaySec);
-    serialInitDelay.sleep();
+    ros::Duration(2.0).sleep();
     ROS_INFO("Initialize MCB serial port '%s' for %d baud",
         serial_params.serial_port.c_str(), serial_params.baud_rate);
 


### PR DESCRIPTION
Inserts a 2 second ROS delay prior to serial port setup. 

Tests so far show this seems to avoid the issue where some OS components sets the serial port to 115200. The odd thing about the defect is stty still shows it as 38.4k but it is in fact 115.2k baud

I am generally against the 'just put a delay in' approach but it is estimated that the root cause here may be extremely complex to find and this bug is impacting a major account thus brute force workaround.  So if a kernel/OS expert wishes to really fix the defect, go for it and simply remove this delay.  Maybe keep the logs so you can see if something shows up between logs like after we init something shows up.  Sadly whatever is doing it is likely NOT going to show up in ros log and would be in an OS log somewhere but at least the timestamps from our logs would get you to the kernel log or perhaps OS log area of interest.

NOTE: This change needs a separate pull request.  Earlier I had formed a branch trying to do this but it had other changes.   So have made this branch and deleted other branch to clean things up.