### PR TITLE
Add mcb message holdoff on host side until MCB indicates no longer busy

### DIFF
--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -155,7 +155,8 @@ private:
     FirmwareParams fw_params;
     FirmwareParams prev_fw_params;
 
-    int32_t mcbIsBusyNow;
+    uint8_t mcbIsBusyNow;
+    uint8_t mcbLastReadReg;
 
     int32_t deadman_timer;
 

--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -127,6 +127,7 @@ public:
     int  getOptionSwitch(void);
     void setOptionSwitchReg(int32_t option_switch);
     void requestSystemEvents();
+    float getBatteryVoltage();
     void setSystemEvents(int32_t system_events);
     int firmware_version;
     int firmware_date;

--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -105,6 +105,8 @@ public:
     virtual ~MotorHardware();
     void clearCommands();
     void readInputs();
+    void transmitMcbCommand(MotorMessage &mcbMessage);
+    int transmitMcbCommands(std::vector<MotorMessage>& commands);
     void writeSpeeds();
     void writeSpeedsInRadians(double  left_radians, double  right_radians);
     void requestFirmwareVersion();
@@ -152,6 +154,8 @@ private:
 
     FirmwareParams fw_params;
     FirmwareParams prev_fw_params;
+
+    int32_t mcbIsBusyNow;
 
     int32_t deadman_timer;
 

--- a/include/ubiquity_motor/motor_message.h
+++ b/include/ubiquity_motor/motor_message.h
@@ -75,7 +75,7 @@ public:
 
     // The byte of the message containing the register address contains a busy bit as of v38
     uint8_t REG_ADDRESS_MASK    = 0x7F; // The register will remain within this mask
-    uint8_t REG_BUSY_IN_PROGRESS = 0x80; // This bit is above address and indicates MCB is busy with a request
+    uint8_t MCB_BUSY_STATE_MASK = 0x80; // This bit is above address and indicates MCB is busy with a request
 
     // Registers enum in class to avoid global namespace pollution
     enum Registers {
@@ -227,7 +227,7 @@ public:
     void setType(MotorMessage::MessageTypes type);
     MotorMessage::MessageTypes getType() const;
 
-    int32_t getBusyWithMsg() const;
+    uint8_t getMcbBusyState() const;
 
     void setRegister(MotorMessage::Registers reg);
     MotorMessage::Registers getRegister() const;
@@ -257,6 +257,8 @@ private:
     uint8_t type;
     // Register address should be in MotorMessage::Registers
     uint8_t register_addr;
+
+    int8_t  mcbBusyState;
 
     // 4 bytes of data, numbers should be in big endian format
     boost::array<uint8_t, 4> data;

--- a/include/ubiquity_motor/motor_message.h
+++ b/include/ubiquity_motor/motor_message.h
@@ -73,6 +73,10 @@ public:
         TYPE_ERROR = 0xD
     };
 
+    // The byte of the message containing the register address contains a busy bit as of v38
+    uint8_t REG_ADDRESS_MASK    = 0x7F; // The register will remain within this mask
+    uint8_t REG_BUSY_IN_PROGRESS = 0x80; // This bit is above address and indicates MCB is busy with a request
+
     // Registers enum in class to avoid global namespace pollution
     enum Registers {
         REG_STOP_START = 0x00,          // Deprecated
@@ -222,6 +226,8 @@ public:
 
     void setType(MotorMessage::MessageTypes type);
     MotorMessage::MessageTypes getType() const;
+
+    int32_t getBusyWithMsg() const;
 
     void setRegister(MotorMessage::Registers reg);
     MotorMessage::Registers getRegister() const;

--- a/include/ubiquity_motor/motor_message.h
+++ b/include/ubiquity_motor/motor_message.h
@@ -52,9 +52,9 @@ typedef boost::array<uint8_t, 8> RawMotorMessage;
 #define MIN_FW_BATTERY_WARN       36
 #define MIN_FW_PID_CONTROL_REV1   37
 #define MIN_FW_WHEEL_TYPE_THIN    37
-#define MIN_FW_SYSTEM_EVENTS      37
 #define MIN_FW_OPTION_SWITCH      37
 #define MIN_FW_PID_RDY_REGS       37
+#define MIN_FW_SYSTEM_EVENTS      38
 
 // It is CRITICAL that the values in the Registers enum remain in sync with Firmware register numbers.
 // In fact once a register is defined and released, it should NOT be re-used at a later time for another purpose

--- a/src/motor_message.cc
+++ b/src/motor_message.cc
@@ -119,8 +119,14 @@ void MotorMessage::setRegister(MotorMessage::Registers reg) {
     }
 }
 
+// Register address is masked off from the byte that also contains busy with msg bit
 MotorMessage::Registers MotorMessage::getRegister() const {
-    return static_cast<MotorMessage::Registers>(this->register_addr);
+    return static_cast<MotorMessage::Registers>((this->register_addr & REG_ADDRESS_MASK));
+}
+
+// Returns non zero if MCB is still busy with a message
+int32_t MotorMessage::getBusyWithMsg() const {
+    return (this->register_addr & REG_BUSY_IN_PROGRESS);
 }
 
 void MotorMessage::setData(int32_t data) {


### PR DESCRIPTION
a new motor_message.h bit called MCB_BUSY_STATE_MASK is allowed to be controlled by firmware.
Host will set a busy state in motor_hardware.cc when sending queries to MCB.
MCB must return any message with this bit cleared (was upper bit of mcb register which we never have used anyway).

The intent of this change is to be backward compatible with existing firmware and allow future firmware such as v38 to extend any MCB busy time within reason as required.

The change as it exists now will give up and send messages if it takes over 200ms so we do not break things badly.
That is a little 'dirty' but frankly for this sort of architectural change so late in the stages of assorted firmware this is cautious.