### PR TITLE
Reinit mcb on mcb reset

### DIFF
--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -141,6 +141,8 @@ public:
     void setOptionSwitchReg(int32_t option_switch);
     void requestSystemEvents();
     void setSystemEvents(int32_t system_events);
+    void getWheelJointPositions(double &leftWheelPosition, double &rightWheelPosition);
+    void setWheelJointVelocities(double leftWheelVelocity, double rightWheelVelocity);
     int firmware_version;
     int firmware_date;
     int firmware_options;
@@ -184,6 +186,12 @@ private:
 
         Joint() : position(0), velocity(0), effort(0), velocity_command(0) {}
     } joints_[2];
+
+    // MessageTypes enum in class to avoid global namespace pollution
+    enum WheelJointNumbers {
+        LEFT_WHEEL_JOINT  = 0,
+        RIGHT_WHEEL_JOINT = 1
+    };
 
     ros::Publisher leftError;
     ros::Publisher rightError;

--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -125,6 +125,8 @@ public:
     void requestFirmwareDate();
     void setParams(FirmwareParams firmware_params);
     void sendParams();
+    void forcePidParamUpdates();
+    float getBatteryVoltage();
     void setDeadmanTimer(int32_t deadman);
     void setDeadzoneEnable(int32_t deadzone_enable);
     void setDebugLeds(bool led1, bool led2);
@@ -135,8 +137,8 @@ public:
     void setMaxFwdSpeed(int32_t max_speed_fwd);
     void setMaxRevSpeed(int32_t max_speed_rev);
     void setMaxPwm(int32_t max_pwm);
-    void setWheelType(int32_t wheel_type);
-    void setWheelDirection(int32_t wheel_direction);
+    void setWheelType(int32_t wheel_type_setting);
+    void setWheelDirection(int32_t wheel_direction_setting);
     int  getOptionSwitch(void);
     void setOptionSwitchReg(int32_t option_switch);
     void requestSystemEvents();
@@ -144,7 +146,7 @@ public:
     int firmware_version;
     int firmware_date;
     int firmware_options;
-    int num_fw_params;  // This is used for sendParams as modulo count
+    int num_fw_params;             // This is used for sendParams as modulo count
     int hardware_version;
     int estop_pid_threshold;
     int max_speed_fwd;
@@ -152,7 +154,8 @@ public:
     int max_pwm;
     int deadman_enable;
     int system_events;
-
+    int wheel_type;
+    int wheel_direction;
 
     diagnostic_updater::Updater diag_updater;
 private:
@@ -170,9 +173,9 @@ private:
 
     int32_t deadman_timer;
 
-    double  ticks_per_radian;       // Odom ticks per radian for wheel encoders in use
+    double  ticks_per_radian;      // Odom ticks per radian for wheel encoders in use
 
-    int32_t sendPid_count;
+    int32_t sendPid_count;         // Used in sendParams() to cycle through MCB parameter updates (Tricky!)
 
     bool estop_motor_power_off;    // Motor power inactive, most likely from ESTOP switch
 

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -41,9 +41,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static const double BILLION = 1000000000.0;
 
-static FirmwareParams firmware_params;
-static CommsParams serial_params;
-static NodeParams node_params;
+// Process global parameters
+static FirmwareParams g_firmware_params;
+static CommsParams g_serial_params;
+static NodeParams g_node_params;
+
+// Until we have a holdoff for MCB message overruns we do this delay to be cautious
+// Twice the period for status reports from MCB
+ros::Duration mcbStatusPeriodSec(0.02);
 
 // Dynamic reconfiguration callback for setting ROS parameters dynamically
 void PID_update_callback(const ubiquity_motor::PIDConfig& config,
@@ -53,37 +58,135 @@ void PID_update_callback(const ubiquity_motor::PIDConfig& config,
     }
 
     if (level == 1) {
-        firmware_params.pid_proportional = config.PID_P;
+        g_firmware_params.pid_proportional = config.PID_P;
     } else if (level == 2) {
-        firmware_params.pid_integral = config.PID_I;
+        g_firmware_params.pid_integral = config.PID_I;
     } else if (level == 4) {
-        firmware_params.pid_derivative = config.PID_D;
+        g_firmware_params.pid_derivative = config.PID_D;
     } else if (level == 8) {
-        firmware_params.pid_denominator = config.PID_C;
+        g_firmware_params.pid_denominator = config.PID_C;
     } else if (level == 16) {
-        firmware_params.pid_moving_buffer_size = config.PID_W;
+        g_firmware_params.pid_moving_buffer_size = config.PID_W;
     } else if (level == 32) {
-        firmware_params.pid_velocity = config.PID_V;
+        g_firmware_params.pid_velocity = config.PID_V;
     } else if (level == 64) {
-        firmware_params.max_pwm = config.MAX_PWM;
+        g_firmware_params.max_pwm = config.MAX_PWM;
     } else {
         ROS_ERROR("Unsupported dynamic_reconfigure level %u", level);
     }
+}
+
+//  initMcbParameters()
+//
+//  Setup MCB parameters that are from host level options or settings
+//
+void initMcbParameters(std::unique_ptr<MotorHardware> &robot )
+{
+    // Force future calls to sendParams() to update current pid parametes on the MCB
+    robot->forcePidParamUpdates();
+
+    // Determine hardware options that can be set by the host to override firmware defaults
+    int32_t wheel_type = 0;
+    if (g_node_params.wheel_type == "firmware_default") {
+        // Here there is no specification so the firmware default will be used
+        ROS_INFO("Firmware default wheel_type will be used.");
+    } else {
+        // Any other setting leads to host setting the wheel type
+        if (g_node_params.wheel_type == "standard") {
+            wheel_type = MotorMessage::OPT_WHEEL_TYPE_STANDARD;
+            ROS_INFO("Host is specifying wheel_type of '%s'", "standard");
+        } else if (g_node_params.wheel_type == "thin"){
+            wheel_type = MotorMessage::OPT_WHEEL_TYPE_THIN;
+            ROS_INFO("Host is specifying wheel_type of '%s'", "thin");
+        } else {
+            ROS_WARN("Invalid wheel_type of '%s' specified! Using wheel type of standard", 
+                g_node_params.wheel_type.c_str());
+            g_node_params.wheel_type = "standard";
+            wheel_type = MotorMessage::OPT_WHEEL_TYPE_STANDARD;
+        }
+        // Write out the wheel type setting
+        robot->setWheelType(wheel_type);
+        mcbStatusPeriodSec.sleep();
+    }
+
+    int32_t wheel_direction = 0;
+    if (g_node_params.wheel_direction == "firmware_default") {
+        // Here there is no specification so the firmware default will be used
+        ROS_INFO("Firmware default wheel_direction will be used.");
+    } else {
+        // Any other setting leads to host setting the wheel type
+        if (g_node_params.wheel_direction == "standard") {
+            wheel_direction = MotorMessage::OPT_WHEEL_DIR_STANDARD;
+            ROS_INFO("Host is specifying wheel_direction of '%s'", "standard");
+        } else if (g_node_params.wheel_direction == "reverse"){
+            wheel_direction = MotorMessage::OPT_WHEEL_DIR_REVERSE;
+            ROS_INFO("Host is specifying wheel_direction of '%s'", "reverse");
+        } else {
+            ROS_WARN("Invalid wheel_direction of '%s' specified! Using wheel direction of standard", 
+                g_node_params.wheel_direction.c_str());
+            g_node_params.wheel_direction = "standard";
+            wheel_direction = MotorMessage::OPT_WHEEL_DIR_STANDARD;
+        }
+        // Write out the wheel direction setting
+        robot->setWheelDirection(wheel_direction);
+        mcbStatusPeriodSec.sleep();
+    }
+
+    // Tell the controller board firmware what version the hardware is at this time.
+    // TODO: Read from I2C.   At this time we only allow setting the version from ros parameters
+    if (robot->firmware_version >= MIN_FW_HW_VERSION_SET) {
+        ROS_INFO_ONCE("Firmware is version %d. Setting Controller board version to %d", 
+            robot->firmware_version, g_firmware_params.controller_board_version);
+        robot->setHardwareVersion(g_firmware_params.controller_board_version);
+        ROS_DEBUG("Controller board version has been set to %d", 
+            g_firmware_params.controller_board_version);
+        mcbStatusPeriodSec.sleep();
+    }
+
+    // Tell the MCB board what the I2C port on it is set to (mcb cannot read it's own switchs!)
+    // We could re-read periodically but perhaps only every 5-10 sec but should do it from main loop
+    if (robot->firmware_version >= MIN_FW_OPTION_SWITCH) {
+        g_firmware_params.option_switch = robot->getOptionSwitch();
+        ROS_INFO("Setting firmware option register to 0x%x.", g_firmware_params.option_switch);
+        robot->setOptionSwitchReg(g_firmware_params.option_switch);
+        mcbStatusPeriodSec.sleep();
+    }
+    
+    if (robot->firmware_version >= MIN_FW_SYSTEM_EVENTS) {
+        // Start out with zero for system events
+        robot->setSystemEvents(0);  // Clear entire system events register
+        robot->system_events = 0;
+        mcbStatusPeriodSec.sleep();
+    }
+
+    // Setup other firmware parameters that could come from ROS parameters
+    if (robot->firmware_version >= MIN_FW_ESTOP_SUPPORT) {
+        robot->setEstopPidThreshold(g_firmware_params.estop_pid_threshold);
+        mcbStatusPeriodSec.sleep();
+        robot->setEstopDetection(g_firmware_params.estop_detection);
+        mcbStatusPeriodSec.sleep();
+    }
+
+    if (robot->firmware_version >= MIN_FW_MAX_SPEED_AND_PWM) {
+        robot->setMaxFwdSpeed(g_firmware_params.max_speed_fwd);
+        mcbStatusPeriodSec.sleep();
+        robot->setMaxRevSpeed(g_firmware_params.max_speed_rev);
+        mcbStatusPeriodSec.sleep();
+    }
+        
+    return;
 }
 
 int main(int argc, char* argv[]) {
     ros::init(argc, argv, "motor_node");
     ros::NodeHandle nh;
 
-    firmware_params = FirmwareParams(nh);
-    serial_params = CommsParams(nh);
-    node_params = NodeParams(nh);
+    // Initialize global parameters
+    g_firmware_params = FirmwareParams(nh);
+    g_serial_params   = CommsParams(nh);
+    g_node_params     = NodeParams(nh);
 
-    ros::Rate ctrlLoopDelay(node_params.controller_loop_rate);
-
-    // Until we have a holdoff for MCB message overruns we do this delay to be cautious
-    // Twice the period for status reports from MCB
-    ros::Duration mcbStatusPeriodSec(0.02);
+    ros::Rate ctrlLoopDelay(g_node_params.controller_loop_rate);
 
     std::unique_ptr<MotorHardware> robot = nullptr;
     // Keep trying to open serial
@@ -91,11 +194,11 @@ int main(int argc, char* argv[]) {
         int times = 0;
         while (ros::ok() && robot.get() == nullptr) {
             try {
-                robot.reset(new MotorHardware(nh, serial_params, firmware_params));
+                robot.reset(new MotorHardware(nh, g_serial_params, g_firmware_params));
             }
             catch (const serial::IOException& e) {
                 if (times % 30 == 0)
-                    ROS_FATAL("Error opening serial port %s, trying again", serial_params.serial_port.c_str());
+                    ROS_FATAL("Error opening serial port %s, trying again", g_serial_params.serial_port.c_str());
             }
             ctrlLoopDelay.sleep();
             times++;
@@ -113,7 +216,7 @@ int main(int argc, char* argv[]) {
     f = boost::bind(&PID_update_callback, _1, _2);
     server.setCallback(f);
 
-    robot->setParams(firmware_params);
+    robot->setParams(g_firmware_params);
     robot->requestFirmwareVersion();
 
     // wait for reply then we know firmware version
@@ -144,94 +247,15 @@ int main(int argc, char* argv[]) {
         robot->requestFirmwareDate();
     }
 
-    // Determine hardware options that can be set by the host to override firmware defaults
-    int32_t wheel_type = 0;
-    if (node_params.wheel_type == "firmware_default") {
-        // Here there is no specification so the firmware default will be used
-        ROS_INFO("Firmware default wheel_type will be used.");
-    } else {
-        // Any other setting leads to host setting the wheel type
-        if (node_params.wheel_type == "standard") {
-            wheel_type = MotorMessage::OPT_WHEEL_TYPE_STANDARD;
-            ROS_INFO("Host is specifying wheel_type of '%s'", "standard");
-        } else if (node_params.wheel_type == "thin"){
-            wheel_type = MotorMessage::OPT_WHEEL_TYPE_THIN;
-            ROS_INFO("Host is specifying wheel_type of '%s'", "thin");
-        } else {
-            ROS_WARN("Invalid wheel_type of '%s' specified! Using wheel type of standard", 
-                node_params.wheel_type.c_str());
-            node_params.wheel_type = "standard";
-            wheel_type = MotorMessage::OPT_WHEEL_TYPE_STANDARD;
-        }
-        // Write out the wheel type setting
-        robot->setWheelType(wheel_type);
-        mcbStatusPeriodSec.sleep();
-    }
+    // Setup MCB parameters that are defined by host parameters in most cases
+    ROS_INFO("Initializing MCB");
+    initMcbParameters(robot);
+    ROS_INFO("Initialization of MCB completed.");
 
-    int32_t wheel_direction = 0;
-    if (node_params.wheel_direction == "firmware_default") {
-        // Here there is no specification so the firmware default will be used
-        ROS_INFO("Firmware default wheel_direction will be used.");
-    } else {
-        // Any other setting leads to host setting the wheel type
-        if (node_params.wheel_direction == "standard") {
-            wheel_direction = MotorMessage::OPT_WHEEL_DIR_STANDARD;
-            ROS_INFO("Host is specifying wheel_direction of '%s'", "standard");
-        } else if (node_params.wheel_direction == "reverse"){
-            wheel_type = MotorMessage::OPT_WHEEL_DIR_REVERSE;
-            ROS_INFO("Host is specifying wheel_direction of '%s'", "reverse");
-        } else {
-            ROS_WARN("Invalid wheel_direction of '%s' specified! Using wheel direction of standard", 
-                node_params.wheel_direction.c_str());
-            node_params.wheel_direction = "standard";
-            wheel_direction = MotorMessage::OPT_WHEEL_DIR_STANDARD;
-        }
-        // Write out the wheel direction setting
-        robot->setWheelDirection(wheel_direction);
-        mcbStatusPeriodSec.sleep();
-    }
-
-    // Tell the controller board firmware what version the hardware is at this time.
-    // TODO: Read from I2C.   At this time we only allow setting the version from ros parameters
-    if (robot->firmware_version >= MIN_FW_HW_VERSION_SET) {
-        ROS_INFO_ONCE("Firmware is version %d. Setting Controller board version to %d", 
-            robot->firmware_version, firmware_params.controller_board_version);
-        robot->setHardwareVersion(firmware_params.controller_board_version);
-        ROS_DEBUG("Controller board version has been set to %d", 
-            firmware_params.controller_board_version);
-        mcbStatusPeriodSec.sleep();
-    }
-
-    // Tell the MCB board what the I2C port on it is set to (mcb cannot read it's own switchs!)
-    // We could re-read periodically but perhaps only every 5-10 sec but should do it from main loop
-    if (robot->firmware_version >= MIN_FW_OPTION_SWITCH) {
-        firmware_params.option_switch = robot->getOptionSwitch();
-        ROS_INFO_ONCE("Setting firmware option register to 0x%x.", firmware_params.option_switch);
-        robot->setOptionSwitchReg(firmware_params.option_switch);
-        mcbStatusPeriodSec.sleep();
-    }
-    
-    if (robot->firmware_version >= MIN_FW_SYSTEM_EVENTS) {
-        // Start out with zero for system events
-        robot->setSystemEvents(0);  // Clear entire system events register
-        robot->system_events = 0;
-        mcbStatusPeriodSec.sleep();
-    }
-
-    // Setup other firmware parameters that could come from ROS parameters
-    if (robot->firmware_version >= MIN_FW_ESTOP_SUPPORT) {
-        robot->setEstopPidThreshold(firmware_params.estop_pid_threshold);
-        mcbStatusPeriodSec.sleep();
-        robot->setEstopDetection(firmware_params.estop_detection);
-        mcbStatusPeriodSec.sleep();
-    }
-
-    if (robot->firmware_version >= MIN_FW_MAX_SPEED_AND_PWM) {
-        robot->setMaxFwdSpeed(firmware_params.max_speed_fwd);
-        mcbStatusPeriodSec.sleep();
-        robot->setMaxRevSpeed(firmware_params.max_speed_rev);
-        mcbStatusPeriodSec.sleep();
-    }
+    // At node startup we clear any MCB events for a clean start
+    robot->setSystemEvents(0);  // Clear entire system events register
+    robot->system_events = 0;
+    mcbStatusPeriodSec.sleep();
 
     ros::Time last_time;
     ros::Time current_time;
@@ -248,7 +272,6 @@ int main(int argc, char* argv[]) {
     float expectedCycleTime = ctrlLoopDelay.expectedCycleTime().toSec();
     float minCycleTime = 0.75 * expectedCycleTime;
     float maxCycleTime = 1.25 * expectedCycleTime;
-
 
     // Clear any commands the robot has at this time
     robot->clearCommands();
@@ -277,7 +300,7 @@ int main(int argc, char* argv[]) {
             cm.update(current_time, ctrlLoopDelay.expectedCycleTime(), true);
             robot->clearCommands();
         }
-        robot->setParams(firmware_params);
+        robot->setParams(g_firmware_params);
         robot->sendParams(); 
 
         // Periodically watch for MCB board having been reset which is an MCB system event
@@ -290,24 +313,27 @@ int main(int argc, char* argv[]) {
             last_sys_maint_time = ros::Time::now();
 
             // Post a status message for MCB state periodically. This may be nice to do more on as required
-            ROS_INFO("Motor controller running. MCB System events 0x%x  Wheel type is '%s'", 
-                robot->system_events, (wheel_type == MotorMessage::OPT_WHEEL_TYPE_THIN) ? "thin" : "standard");
+            ROS_INFO("Battery = %5.2f volts, MCB system events 0x%x, Wheel type '%s'",
+                robot->getBatteryVoltage(), robot->system_events, 
+                (robot->wheel_type == MotorMessage::OPT_WHEEL_TYPE_THIN) ? "thin" : "standard");
 
             // If we detect a power-on of MCB we should re-initialize MCB
             if ((robot->system_events & MotorMessage::SYS_EVENT_POWERON) != 0) {
-                ROS_WARN("Detected Motor controller PowerOn event!");
+                ROS_WARN("Detected Motor controller PowerOn event! Re-initialize MCB");
                 robot->setSystemEvents(0);  // Clear entire system events register
                 robot->system_events = 0;
                 mcbStatusPeriodSec.sleep();
               
-                // TODO: Need to re-initialize MCB here. Refer to ubiquity_motor issue #98
+                // Setup MCB parameters that are defined by host parameters in most cases
+                initMcbParameters(robot);
+                ROS_WARN("Motor controller has been re-initialized");
             }
 
             // a periodic refresh of wheel type which is a safety net due to it's importance.
             // This can be removed when a solid message protocol is developed
             if (robot->firmware_version >= MIN_FW_WHEEL_TYPE_THIN) {
                 // Refresh the wheel type setting
-                robot->setWheelType(wheel_type);
+                robot->setWheelType(robot->wheel_type);
                 mcbStatusPeriodSec.sleep();
             }
         }
@@ -319,7 +345,7 @@ int main(int argc, char* argv[]) {
         } else {
             if (estopReleaseDelay > 0.0) {
                 // Implement a delay after estop release where velocity remains zero
-                estopReleaseDelay -= (1.0/node_params.controller_loop_rate);
+                estopReleaseDelay -= (1.0/g_node_params.controller_loop_rate);
                 robot->writeSpeedsInRadians(0.0, 0.0);
             } else {
                 robot->writeSpeeds();   // Normal operation using current system speeds

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -233,7 +233,7 @@ int main(int argc, char* argv[]) {
         mcbStatusPeriodSec.sleep();
     }
 
-    ros::Time last_time;
+    ros::Time last_loop_time;
     ros::Time current_time;
     ros::Duration elapsed;
     ros::Duration sysMaintPeriod(60.0);     // A periodic MCB maintenance operation
@@ -249,13 +249,21 @@ int main(int argc, char* argv[]) {
     float minCycleTime = 0.75 * expectedCycleTime;
     float maxCycleTime = 1.25 * expectedCycleTime;
 
-
     // Clear any commands the robot has at this time
     robot->clearCommands();
 
-    last_time = ros::Time::now();
-    ros::Time last_sys_maint_time = last_time;
+    last_loop_time = ros::Time::now();
+    ros::Time last_sys_maint_time = last_loop_time;
     ros::Duration elapsed_since_last_action;
+
+    double leftWheelVelocity  = 0.0;
+    double leftWheelPosition  = 0.0;
+    double leftLastWheelPos   = 0.0;
+    double rightWheelVelocity = 0.0;
+    double rightWheelPosition = 0.0;
+    double rightLastWheelPos  = 0.0;
+    robot-> getWheelJointPositions(leftLastWheelPos, rightWheelPosition);
+    ctrlLoopDelay.sleep(); // We do this delay so velocity calc uses non-zero time
 
     ROS_WARN("Starting motor control node now");
 
@@ -264,10 +272,19 @@ int main(int argc, char* argv[]) {
     double estopReleaseDelay    = 0.0;
     while (ros::ok()) {
         current_time = ros::Time::now();
-        elapsed = current_time - last_time;
-        last_time = current_time;
-        robot->readInputs();
+        elapsed = current_time - last_loop_time;
+        last_loop_time = current_time;
         float elapsedSecs = elapsed.toSec();
+
+        // Determine and set measured wheel velocities in rad/sec from hardware positions in radians
+        robot-> getWheelJointPositions(leftWheelPosition, rightWheelPosition);
+        leftWheelVelocity  = (leftWheelPosition  - leftLastWheelPos)  / elapsedSecs;
+        rightWheelVelocity = (rightWheelPosition - rightLastWheelPos) / elapsedSecs;
+        robot-> setWheelJointVelocities(leftWheelVelocity, rightWheelVelocity);  // units are rad/sec
+        leftLastWheelPos  = leftWheelPosition;
+        rightLastWheelPos = rightWheelPosition;
+
+        robot->readInputs();
         if (minCycleTime < elapsedSecs && elapsedSecs < maxCycleTime) {
             cm.update(current_time, elapsed);
         }


### PR DESCRIPTION
We had before detected that the MCB had been reset using a system event.  We only stated it in the log.

This change when seeing an MCB reset re-initializes the MCB with any ROS parameters that the host would normally have only setup on the MCB at startup.  Now a large routine called initMcbParameters() is used.

The next involved change is a lot of variable renames mostly to indicate they are globals in many case.
This change will mean there will be merge conflicts.

before the push of this branch did this merge:  git merge --no-ff fixJointStateVelocities