### PR TITLE
Better namespacing of parameters to allow multiple motor nodes

### DIFF
--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -127,7 +127,7 @@ struct MotorDiagnostics {
 
 class MotorHardware : public hardware_interface::RobotHW {
 public:
-    MotorHardware(ros::NodeHandle nh, CommsParams serial_params,
+    MotorHardware(ros::NodeHandle nh, NodeParams node_params, CommsParams serial_params,
                   FirmwareParams firmware_params);
     virtual ~MotorHardware();
     void clearCommands();

--- a/include/ubiquity_motor/motor_parameters.h
+++ b/include/ubiquity_motor/motor_parameters.h
@@ -114,41 +114,41 @@ struct FirmwareParams {
         {
         // clang-format off
         pid_proportional = getParamOrDefault(
-            nh, "ubiquity_motor/pid_proportional", pid_proportional);
+            nh, "pid_proportional", pid_proportional);
         pid_integral = getParamOrDefault(
-            nh, "ubiquity_motor/pid_integral", pid_integral);
+            nh, "pid_integral", pid_integral);
         pid_derivative = getParamOrDefault(
-            nh, "ubiquity_motor/pid_derivative", pid_derivative);
+            nh, "pid_derivative", pid_derivative);
         pid_velocity = getParamOrDefault(
-            nh, "ubiquity_motor/pid_velocity", pid_velocity);
+            nh, "pid_velocity", pid_velocity);
         pid_denominator = getParamOrDefault(
-            nh, "ubiquity_motor/pid_denominator", pid_denominator);
+            nh, "pid_denominator", pid_denominator);
         pid_moving_buffer_size = getParamOrDefault(
-            nh, "ubiquity_motor/window_size", pid_moving_buffer_size);
+            nh, "window_size", pid_moving_buffer_size);
         controller_board_version = getParamOrDefault(
-            nh, "ubiquity_motor/controller_board_version", controller_board_version);
+            nh, "controller_board_version", controller_board_version);
         estop_detection = getParamOrDefault(
-            nh, "ubiquity_motor/fw_estop_detection", estop_detection);
+            nh, "fw_estop_detection", estop_detection);
         estop_pid_threshold = getParamOrDefault(
-            nh, "ubiquity_motor/fw_estop_pid_threshold", estop_pid_threshold);
+            nh, "fw_estop_pid_threshold", estop_pid_threshold);
         max_speed_fwd = getParamOrDefault(
-            nh, "ubiquity_motor/fw_max_speed_fwd", max_speed_fwd);
+            nh, "fw_max_speed_fwd", max_speed_fwd);
         max_speed_rev = getParamOrDefault(
-            nh, "ubiquity_motor/fw_max_speed_rev", max_speed_rev);
+            nh, "fw_max_speed_rev", max_speed_rev);
         max_pwm = getParamOrDefault(
-            nh, "ubiquity_motor/fw_max_pwm", max_pwm);
+            nh, "fw_max_pwm", max_pwm);
         deadman_timer = getParamOrDefault(
-            nh, "ubiquity_motor/deadman_timer", deadman_timer);
+            nh, "deadman_timer", deadman_timer);
         deadzone_enable = getParamOrDefault(
-            nh, "ubiquity_motor/deadzone_enable", deadzone_enable);
+            nh, "deadzone_enable", deadzone_enable);
         battery_voltage_offset = getParamOrDefault(
-            nh, "ubiquity_motor/battery_voltage_offset", battery_voltage_offset);
+            nh, "battery_voltage_offset", battery_voltage_offset);
         battery_voltage_multiplier = getParamOrDefault(
-            nh, "ubiquity_motor/battery_voltage_multiplier", battery_voltage_multiplier);
+            nh, "battery_voltage_multiplier", battery_voltage_multiplier);
         battery_voltage_low_level = getParamOrDefault(
-            nh, "ubiquity_motor/battery_voltage_low_level", battery_voltage_low_level);
+            nh, "battery_voltage_low_level", battery_voltage_low_level);
         battery_voltage_critical = getParamOrDefault(
-            nh, "ubiquity_motor/battery_voltage_critical", battery_voltage_critical);
+            nh, "battery_voltage_critical", battery_voltage_critical);
         // clang-format on
     };
 };
@@ -164,9 +164,9 @@ struct CommsParams {
         : serial_port("/dev/ttyS0"), baud_rate(9600) {
         // clang-format off
         serial_port = getParamOrDefault(
-            nh, "ubiquity_motor/serial_port", serial_port);
+            nh, "serial_port", serial_port);
         baud_rate = getParamOrDefault(
-            nh, "ubiquity_motor/serial_baud", baud_rate);
+            nh, "serial_baud", baud_rate);
         // clang-format on
     };
 };
@@ -176,17 +176,30 @@ struct NodeParams {
     std::string wheel_type;
     std::string wheel_direction;
 
-    NodeParams() : controller_loop_rate(10.0), wheel_type("firmware_default"), wheel_direction("firmware_default"){};
+    std::string left_joint;
+    std::string right_joint;
+
+    NodeParams()
+        : controller_loop_rate(10.0),
+          wheel_type("firmware_default"),
+          wheel_direction("firmware_default"),
+	  left_joint("left_wheel_joint"),
+	  right_joint("right_wheel_joint"){};
+
     NodeParams(ros::NodeHandle nh) : controller_loop_rate(10.0),
         wheel_type("firmware_default"),
         wheel_direction("firmware_default") {
         // clang-format off
         controller_loop_rate = getParamOrDefault(
-            nh, "ubiquity_motor/controller_loop_rate", controller_loop_rate);
+            nh, "controller_loop_rate", controller_loop_rate);
         wheel_type = getParamOrDefault(
-            nh, "ubiquity_motor/wheel_type", wheel_type);
+            nh, "wheel_type", wheel_type);
         wheel_direction = getParamOrDefault(
-            nh, "ubiquity_motor/wheel_direction", wheel_direction);
+            nh, "wheel_direction", wheel_direction);
+        left_joint = getParamOrDefault(
+            nh, "left_joint", left_joint);
+        right_joint = getParamOrDefault(
+            nh, "right_joint", right_joint);
         // clang-format on
     };
 };

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -67,11 +67,9 @@ int32_t  g_odomEvent = 0;
 static int i2c_BufferRead(const char *i2cDevFile, uint8_t i2cAddr, 
                           uint8_t* pBuffer, int16_t chipRegAddr, uint16_t NumByteToRead);
 
-
-MotorHardware::MotorHardware(ros::NodeHandle nh, CommsParams serial_params,
+MotorHardware::MotorHardware(ros::NodeHandle nh, NodeParams node_params, CommsParams serial_params,
                              FirmwareParams firmware_params) {
-    ros::V_string joint_names =
-        boost::assign::list_of("left_wheel_joint")("right_wheel_joint");
+    ros::V_string joint_names = boost::assign::list_of(node_params.left_joint)(node_params.right_joint);
 
     for (size_t i = 0; i < joint_names.size(); i++) {
         hardware_interface::JointStateHandle joint_state_handle(

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -74,10 +74,11 @@ void PID_update_callback(const ubiquity_motor::PIDConfig& config,
 int main(int argc, char* argv[]) {
     ros::init(argc, argv, "motor_node");
     ros::NodeHandle nh;
-
-    firmware_params = FirmwareParams(nh);
-    serial_params = CommsParams(nh);
-    node_params = NodeParams(nh);
+    ros::NodeHandle pnh("~");
+    
+    firmware_params = FirmwareParams(pnh);
+    serial_params = CommsParams(pnh);
+    node_params = NodeParams(pnh);
 
     ros::Rate ctrlLoopDelay(node_params.controller_loop_rate);
 
@@ -91,7 +92,7 @@ int main(int argc, char* argv[]) {
         int times = 0;
         while (ros::ok() && robot.get() == nullptr) {
             try {
-                robot.reset(new MotorHardware(nh, serial_params, firmware_params));
+                robot.reset(new MotorHardware(nh, node_params, serial_params, firmware_params));
             }
             catch (const serial::IOException& e) {
                 if (times % 30 == 0)


### PR DESCRIPTION
Parameterize joint names.

On a standard magni this will change the parameter names to "motor_node/" instead of "ubiquity_motor/", but it will allow multiple instances of ubiquity_motor to have different parameters.