### PR TITLE
Add system control for mcb disable

### DIFF
--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -118,7 +118,7 @@ public:
                   FirmwareParams firmware_params);
     virtual ~MotorHardware();
     void closePort();
-    void openPort();
+    bool openPort();
     void clearCommands();
     void readInputs();
     void writeSpeeds();

--- a/include/ubiquity_motor/motor_hardware.h
+++ b/include/ubiquity_motor/motor_hardware.h
@@ -117,6 +117,8 @@ public:
     MotorHardware(ros::NodeHandle nh, CommsParams serial_params,
                   FirmwareParams firmware_params);
     virtual ~MotorHardware();
+    void closePort();
+    void openPort();
     void clearCommands();
     void readInputs();
     void writeSpeeds();

--- a/include/ubiquity_motor/motor_serial.h
+++ b/include/ubiquity_motor/motor_serial.h
@@ -51,6 +51,8 @@ public:
 
     MotorMessage receiveCommand();
     int commandAvailable();
+    void closePort();
+    int  openPort();
 
     MotorSerial(MotorSerial const&) = delete;
     MotorSerial& operator=(MotorSerial const&) = delete;

--- a/include/ubiquity_motor/motor_serial.h
+++ b/include/ubiquity_motor/motor_serial.h
@@ -52,7 +52,7 @@ public:
     MotorMessage receiveCommand();
     int commandAvailable();
     void closePort();
-    int  openPort();
+    bool openPort();
 
     MotorSerial(MotorSerial const&) = delete;
     MotorSerial& operator=(MotorSerial const&) = delete;

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -485,13 +485,21 @@ void MotorHardware::setMaxFwdSpeed(int32_t max_speed_fwd) {
 // Setup the Wheel Type. Overrides mode in use on hardware
 // This used to only be standard but THIN_WHEELS were added in Jun 2020
 void MotorHardware::setWheelType(int32_t new_wheel_type) {
-    ROS_INFO_ONCE("setting MCB wheel type %d", (int)wheel_type);
-    wheel_type = new_wheel_type;
+
     MotorMessage ho;
-    ho.setRegister(MotorMessage::REG_WHEEL_TYPE);
-    ho.setType(MotorMessage::TYPE_WRITE);
-    ho.setData(wheel_type);
-    motor_serial_->transmitCommand(ho);
+    switch(new_wheel_type) {
+        case MotorMessage::OPT_WHEEL_TYPE_STANDARD:
+        case MotorMessage::OPT_WHEEL_TYPE_THIN:
+            ROS_INFO_ONCE("setting MCB wheel type %d", (int)new_wheel_type);
+            wheel_type = new_wheel_type;
+            ho.setRegister(MotorMessage::REG_WHEEL_TYPE);
+            ho.setType(MotorMessage::TYPE_WRITE);
+            ho.setData(wheel_type);
+            motor_serial_->transmitCommand(ho);
+            break;
+        default:
+            ROS_ERROR("Illegal MCB wheel type 0x%x will not be set!", (int)new_wheel_type);
+    }
 }
 
 // Setup the Wheel direction. Overrides mode in use on hardware

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -153,6 +153,17 @@ MotorHardware::MotorHardware(ros::NodeHandle nh, CommsParams serial_params,
 
 MotorHardware::~MotorHardware() { delete motor_serial_; }
 
+// Close of the serial port is used in a special case of suspending the motor controller
+// so that another service can load firmware or do direct MCB diagnostics
+void MotorHardware::closePort() {
+    motor_serial_->closePort();
+}
+
+// After we have given up the MCB we open serial port again using current instance of Serial
+void MotorHardware::openPort() {
+    motor_serial_->openPort();
+}
+
 void MotorHardware::clearCommands() {
     for (size_t i = 0; i < sizeof(joints_) / sizeof(joints_[0]); i++) {
         joints_[i].velocity_command = 0;

--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -160,8 +160,8 @@ void MotorHardware::closePort() {
 }
 
 // After we have given up the MCB we open serial port again using current instance of Serial
-void MotorHardware::openPort() {
-    motor_serial_->openPort();
+bool MotorHardware::openPort() {
+    return motor_serial_->openPort();
 }
 
 void MotorHardware::clearCommands() {

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -88,16 +88,14 @@ void PID_update_callback(const ubiquity_motor::PIDConfig& config,
 // and thus allow live firmware updates or other direct MCB serial communications to happen
 // without the main control code trying to talk to the MCB
 void SystemControlCallback(const std_msgs::String::ConstPtr& msg) {
-    ROS_INFO("System control msg with content: '%s']", msg->data.c_str());
+    ROS_DEBUG("System control msg with content: '%s']", msg->data.c_str());
 
-    if ( msg->data.find(MOTOR_CONTROL_CMD) >= 0) {
-        // This is a motor control command.  See if it matches our known commands
-        if (msg->data.find(MOTOR_CONTROL_ENABLE) >= 0) {
-            ROS_INFO("System control msg to ENABLE control to MCB");
+    if (msg->data.find(MOTOR_CONTROL_CMD) != std::string::npos) {
+        if (msg->data.find(MOTOR_CONTROL_ENABLE) != std::string::npos) {;
+            ROS_INFO("Received System control msg to ENABLE control of the MCB");
             g_mcbEnabled = 1;
-        }
-        if (msg->data.find(MOTOR_CONTROL_ENABLE) >= 0) {
-            ROS_INFO("System control msg to DISABLtr control to MCB");
+        } else if (msg->data.find(MOTOR_CONTROL_DISABLE) != std::string::npos) {
+            ROS_INFO("Received System control msg to DISABLE control of the MCB");
             g_mcbEnabled = 0;
         }
      }

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -111,7 +111,7 @@ void initMcbParameters(std::unique_ptr<MotorHardware> &robot )
     robot->forcePidParamUpdates();
 
     // Determine hardware options that can be set by the host to override firmware defaults
-    int32_t wheel_type = 0;
+    int32_t wheel_type = MotorMessage::OPT_WHEEL_TYPE_STANDARD;
     if (g_node_params.wheel_type == "firmware_default") {
         // Here there is no specification so the firmware default will be used
         ROS_INFO("Firmware default wheel_type will be used.");
@@ -383,9 +383,15 @@ int main(int argc, char* argv[]) {
             mcbStatusPeriodSec.sleep();
             last_sys_maint_time = ros::Time::now();
 
+			// See if we are in a low battery voltage state
+			std::string batStatus = "OK";
+			if (robot->getBatteryVoltage() < g_firmware_params.battery_voltage_low_level) {
+			    batStatus = "LOW!";
+			}
+
             // Post a status message for MCB state periodically. This may be nice to do more on as required
-            ROS_INFO("Battery = %5.2f volts, MCB system events 0x%x, Wheel type '%s'",
-                robot->getBatteryVoltage(), robot->system_events, 
+            ROS_INFO("Battery = %5.2f volts [%s], MCB system events 0x%x, Wheel type '%s'",
+                robot->getBatteryVoltage(), batStatus.c_str(), robot->system_events, 
                 (robot->wheel_type == MotorMessage::OPT_WHEEL_TYPE_THIN) ? "thin" : "standard");
 
             // If we detect a power-on of MCB we should re-initialize MCB

--- a/src/motor_node.cc
+++ b/src/motor_node.cc
@@ -343,16 +343,22 @@ int main(int argc, char* argv[]) {
         }
 
         if (lastMcbEnabled == 0) {        // Were disabled but re-enabled so re-setup mcb
+            bool portOpenStatus;
             lastMcbEnabled = 1;
             ROS_WARN("Motor controller went from offline to online!");
-            robot->openPort();          // Must re-open serial port
-            robot->setSystemEvents(0);  // Clear entire system events register
-            robot->system_events = 0;
-            mcbStatusPeriodSec.sleep();
+            portOpenStatus = robot->openPort();  // Must re-open serial port
+            if (portOpenStatus == true) {
+                robot->setSystemEvents(0);  // Clear entire system events register
+                robot->system_events = 0;
+                mcbStatusPeriodSec.sleep();
               
-            // Setup MCB parameters that are defined by host parameters in most cases
-            initMcbParameters(robot);
-            ROS_WARN("Motor controller has been re-initialized as we go back online");
+                // Setup MCB parameters that are defined by host parameters in most cases
+                initMcbParameters(robot);
+                ROS_WARN("Motor controller has been re-initialized as we go back online");
+            } else {
+                // We do not have recovery from this situation and it seems not possible
+                ROS_ERROR("ERROR in re-opening of the Motor controller!");
+            }
         }
 
         // Determine and set wheel velocities in rad/sec from hardware positions in rads

--- a/src/motor_serial.cc
+++ b/src/motor_serial.cc
@@ -78,9 +78,32 @@ void MotorSerial::appendOutput(MotorMessage command) { output.push(command); }
 void MotorSerial::closePort() { return motors.close(); }
 
 // After we have been offine this is called to re-open serial port
-int MotorSerial::openPort()  { 
-    //  TODO:  May need to be a bit clever here to do the   motors.open();
-    return 0;
+// This returns true if port was open or if port opened with success
+bool MotorSerial::openPort()  { 
+    bool retCode = true;
+
+    if (motors.isOpen() == true) {
+        return true; 
+    }
+
+    //  Port was closed so must open it using info from prior open()
+    try {
+        motors.open();
+    } catch (const serial::IOException& e) {
+        ROS_ERROR("%s", e.what());
+        retCode = false;
+    } catch (const std::invalid_argument) {
+        ROS_ERROR("MotorSerial::openPort Invalid argument");
+        retCode = false;
+    } catch (const serial::SerialException& e) {
+        ROS_ERROR("%s", e.what());
+        retCode = false;
+    } catch (...) {
+        ROS_ERROR("Unknown Error");
+        retCode = false;
+    }
+
+    return retCode;
 }
 
 void MotorSerial::SerialThread() {

--- a/src/motor_serial.cc
+++ b/src/motor_serial.cc
@@ -75,6 +75,14 @@ int MotorSerial::commandAvailable() { return !output.fast_empty(); }
 
 void MotorSerial::appendOutput(MotorMessage command) { output.push(command); }
 
+void MotorSerial::closePort() { return motors.close(); }
+
+// After we have been offine this is called to re-open serial port
+int MotorSerial::openPort()  { 
+    //  TODO:  May need to be a bit clever here to do the   motors.open();
+    return 0;
+}
+
 void MotorSerial::SerialThread() {
     try {
         while (motors.isOpen()) {


### PR DESCRIPTION
We add ability to disable and re-enable motor node ownership of MCB through serial port close and re-open.
All control is done using motor_node listing to topic  /system_control   The following strings control operation
-  motor_control  disable
- motor_control   enable