### PR TITLE
Adding system_control command of speed_control  and cleanup of mcb disable

### DIFF
--- a/include/ubiquity_motor/motor_parameters.h
+++ b/include/ubiquity_motor/motor_parameters.h
@@ -33,6 +33,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ros/ros.h>
 
+// These defines are for a high level topic for control of the motor node at a system level
+#define ROS_TOPIC_SYSTEM_CONTROL  "system_control"    // A topic for system level control commands
+#define MOTOR_CONTROL_CMD         "motor_control"     // A mnumonic for a motor control system command
+#define MOTOR_CONTROL_ENABLE      "enable"            // Parameter for MOTOR_CONTROL_CMD to enable control
+#define MOTOR_CONTROL_DISABLE     "disable"           // Parameter for MOTOR_CONTROL_CMD to enable control
+#define MOTOR_SPEED_CONTROL_CMD   "speed_control"     // A mnumonic for disable of speed to avoid colision
+
 template <typename T>
 T getParamOrDefault(ros::NodeHandle nh, std::string parameter_name,
                     T default_val) {
@@ -176,10 +183,16 @@ struct NodeParams {
     std::string wheel_type;
     std::string wheel_direction;
 
-    NodeParams() : controller_loop_rate(10.0), wheel_type("firmware_default"), wheel_direction("firmware_default"){};
+    int mcbControlEnabled;    // State to allow suspension of MCB serial control for diagnostic purposes
+    int mcbSpeedEnabled;      // State to allow zero speed override for safety reasons
+
+    NodeParams() : controller_loop_rate(10.0), wheel_type("firmware_default"), wheel_direction("firmware_default"),
+        mcbControlEnabled(1), mcbSpeedEnabled(1){};
     NodeParams(ros::NodeHandle nh) : controller_loop_rate(10.0),
         wheel_type("firmware_default"),
-        wheel_direction("firmware_default") {
+        wheel_direction("firmware_default"),
+        mcbControlEnabled(1),
+        mcbSpeedEnabled(1) {
         // clang-format off
         controller_loop_rate = getParamOrDefault(
             nh, "ubiquity_motor/controller_loop_rate", controller_loop_rate);


### PR DESCRIPTION
Adding to topic system_control ability to halt the robot for collision usage from outside this node.

Moving the state for both speed control AND earlier added motor control to disable mcb control by motor node both into NodeParams class.    Also move the defines for topic name and both commands into motor_parameters.h which is better place since now mcbSpeedControl and mcbMotorControl are now members of NodeParams which is also defined in motor_parameters.h