### PR TITLE
[Diagnostics] Motor Power being on is not an error

### DIFF
--- a/src/motor_hardware.cc
+++ b/src/motor_hardware.cc
@@ -921,7 +921,7 @@ void MotorDiagnostics::motor_max_pwm_status(DiagnosticStatusWrapper &stat) {
 void MotorDiagnostics::motor_power_status(DiagnosticStatusWrapper &stat) {
     stat.add("Motor Power", !estop_motor_power_off);
     if (estop_motor_power_off == false) {
-        stat.summary(DiagnosticStatusWrapper::ERROR, "Motor power on");
+        stat.summary(DiagnosticStatusWrapper::OK, "Motor power on");
     }
     else {
         stat.summary(DiagnosticStatusWrapper::WARN, "Motor power off");


### PR DESCRIPTION
The error diagnostic status should be used to indicate that something is wrong,
the motor power being on is not an error, it is an expected part of
normal operation.