### PR TITLE
made upgrade_firmware be run with py2

### DIFF
--- a/scripts/upgrade_firmware.py
+++ b/scripts/upgrade_firmware.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python2
 import requests
 
 import time


### PR DESCRIPTION
As discussed in #149 the upgrade firmware script has still not been fully ported to py3. This is the only reason why we are still installing python2 on all noetic images. Now because upgrade_firmware.py doesnt actually use ros lib we can still call it using rosrun, we just need to indicate that this is py2 executable as was done here. Previously you had to run with 

`python2 ~/catkin_ws/src/ubiquity_motor/scripts/upgrade_firmware.py --file  /home/ubuntu/catkin_ws/src/ubiquity_motor/firmware/v40_20201209_enc.cyacd
`
(you also HAD to have the ubiquity_motor cloned - installing throuhg apt did not work)

with this fix you can trigger update with 

`rosrun ubiquity_motor upgrade_firmware.py --file v43_20210829_enc.cyacd `

and it all works also installing ubiquity_motor through apt.

Testing on rpi, noetic image:

```
sudo apt remove ros-noetic-ubiquity-motor # remove the old ubiq motor installation
cd ~/catkin_ws/src/
git clone https://github.com/UbiquityRobotics/ubiquity_motor.git --branch bugfix-upgradefirmwarepy2
cd ~/catkin_ws/
catkin_make -j2
source devel/setup.bash 
rosrun ubiquity_motor upgrade_firmware.py --file /home/ubuntu/catkin_ws/src/ubiquity_motor/firmware/v43_20210829_enc.cyacd
```

and the firmware should be updated
